### PR TITLE
Added appbar at the top of the SettingsActivity

### DIFF
--- a/app/src/main/java/net/schueller/peertube/activity/SettingsActivity.java
+++ b/app/src/main/java/net/schueller/peertube/activity/SettingsActivity.java
@@ -38,10 +38,23 @@ public class SettingsActivity extends CommonActivity {
                 .beginTransaction()
                 .replace(R.id.settings, new SettingsFragment())
                 .commit();
+
+        // Attaching the layout to the toolbar object
+        Toolbar toolbar = findViewById(R.id.tool_bar_settings);
+        // Setting toolbar as the ActionBar with setSupportActionBar() call
+        setSupportActionBar(toolbar);
+
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setHomeAsUpIndicator(R.drawable.ic_baseline_close_24);
         }
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        finish(); // close this activity as oppose to navigating up
+        return false;
     }
 
     public static class SettingsFragment extends PreferenceFragmentCompat {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,6 +1,21 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_settings"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/tool_bar_settings"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:elevation="4dp" />
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout
         android:id="@+id/settings"


### PR DESCRIPTION
I noticed the "Account" activity (MeActivity) had an appbar at the top.

I therefore shamelessly copied most of its code and added it into SettingsActivity, so that we have a similar appbar there, which makes for more consistency throughout the app:

![image](https://user-images.githubusercontent.com/20014332/86515768-c19e6880-be1b-11ea-9df6-8f6212a492df.png)
