### PR TITLE
Ignore icon reserved space for preferences in SettingsActivity

### DIFF
--- a/app/src/main/java/net/schueller/peertube/activity/SettingsActivity.java
+++ b/app/src/main/java/net/schueller/peertube/activity/SettingsActivity.java
@@ -25,8 +25,6 @@ import androidx.preference.PreferenceFragmentCompat;
 
 import net.schueller.peertube.R;
 
-import java.util.Objects;
-
 public class SettingsActivity extends CommonActivity {
 
     @Override

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -1,6 +1,6 @@
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <PreferenceCategory app:title="@string/settings_activity_look_and_feel_category_title">
+    <PreferenceCategory app:title="@string/settings_activity_look_and_feel_category_title" app:iconSpaceReserved="false">
 
         <ListPreference
             app:defaultValue="@array/empty_array"
@@ -8,7 +8,8 @@
             app:entryValues="@array/supportedLanguagesValues"
             app:key="pref_language_app"
             app:summary="@string/pref_description_language_app"
-            app:title="@string/pref_language_app" />
+            app:title="@string/pref_language_app"
+            app:iconSpaceReserved="false"/>
 
         <ListPreference
             app:defaultValue="AppTheme.BLUE"
@@ -16,23 +17,26 @@
             app:entryValues="@array/themeValues"
             app:key="pref_theme"
             app:summary="@string/pref_description_app_theme"
-            app:title="@string/pref_title_app_theme" />
+            app:title="@string/pref_title_app_theme"
+            app:iconSpaceReserved="false"/>
 
         <SwitchPreference
             app:defaultValue="false"
             app:key="pref_dark_mode"
             app:summary="@string/pref_description_dark_mode"
-            app:title="@string/pref_title_dark_mode" />
+            app:title="@string/pref_title_dark_mode"
+            app:iconSpaceReserved="false"/>
 
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_activity_video_list_category_title">
+    <PreferenceCategory app:title="@string/settings_activity_video_list_category_title" app:iconSpaceReserved="false">
 
         <SwitchPreference
             app:defaultValue="false"
             app:key="pref_show_nsfw"
             app:summary="@string/pref_description_show_nsfw"
-            app:title="@string/pref_title_show_nsfw" />
+            app:title="@string/pref_title_show_nsfw"
+            app:iconSpaceReserved="false"/>
 
         <MultiSelectListPreference
             app:defaultValue="@array/empty_array"
@@ -40,17 +44,19 @@
             app:entryValues="@array/languageValues"
             app:key="pref_language"
             app:summary="@string/pref_description_language"
-            app:title="@string/pref_language" />
+            app:title="@string/pref_language"
+            app:iconSpaceReserved="false"/>
 
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_activity_video_playback_category_title">
+    <PreferenceCategory app:title="@string/settings_activity_video_playback_category_title" app:iconSpaceReserved="false">
 
         <SwitchPreference
             app:defaultValue="true"
             app:key="pref_back_pause"
             app:summary="@string/pref_description_back_pause"
-            app:title="@string/pref_title_back_pause" />
+            app:title="@string/pref_title_back_pause"
+            app:iconSpaceReserved="false"/>
 
         <ListPreference
             app:defaultValue="@array/empty_array"
@@ -58,25 +64,29 @@
             app:entryValues="@array/backgroundBehaviorValues"
             app:key="pref_background_behavior"
             app:summary="@string/pref_background_behavior_summary"
-            app:title="@string/pref_background_behavior" />
+            app:title="@string/pref_background_behavior"
+            app:iconSpaceReserved="false"/>
 
         <SwitchPreference
             app:defaultValue="false"
             app:key="pref_torrent_player"
             app:summary="@string/pref_description_torrent_player"
-            app:title="@string/pref_title_torrent_player" />
+            app:title="@string/pref_title_torrent_player"
+            app:iconSpaceReserved="false"/>
 
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_activity_about_category_title">
+    <PreferenceCategory app:title="@string/settings_activity_about_category_title" app:iconSpaceReserved="false">
 
         <Preference
             app:summary="@string/versionName"
-            app:title="@string/pref_title_version" />
+            app:title="@string/pref_title_version"
+            app:iconSpaceReserved="false"/>
 
         <Preference
             app:summary="@string/pref_description_license"
-            app:title="@string/pref_title_license" />
+            app:title="@string/pref_title_license"
+            app:iconSpaceReserved="false"/>
 
 
     </PreferenceCategory>


### PR DESCRIPTION
Android reserves some space next to a preference to let developers put an icon there.
As there aren't any icons, I added `app:iconSpaceReserved="false"` to all the preferences in order to "remove" this useless blank space.

This is how it looks now:
![image](https://user-images.githubusercontent.com/20014332/86519870-5797ba80-be3f-11ea-9885-721dfc1bdd1c.png)
