### PR TITLE
 Added preview of the current playback speed and video quality in the VideoOptionsFragment

### DIFF
--- a/app/src/main/java/net/schueller/peertube/fragment/VideoMenuQualityFragment.java
+++ b/app/src/main/java/net/schueller/peertube/fragment/VideoMenuQualityFragment.java
@@ -17,6 +17,7 @@
  */
 package net.schueller.peertube.fragment;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -44,7 +45,7 @@ public class VideoMenuQualityFragment extends BottomSheetDialogFragment {
     public static final String TAG = "VideoMenuQuality";
     private static File autoQualityFile;
 
-    public static VideoMenuQualityFragment newInstance(ArrayList<File> files) {
+    public static VideoMenuQualityFragment newInstance(Context context, ArrayList<File> files) {
 
         mFiles = files;
 
@@ -53,7 +54,7 @@ public class VideoMenuQualityFragment extends BottomSheetDialogFragment {
             autoQualityFile = new File();
             Resolution autoQualityResolution = new Resolution();
             autoQualityResolution.setId(0);
-            autoQualityResolution.setLabel("Auto");
+            autoQualityResolution.setLabel(context.getString(R.string.menu_video_options_quality_automated));
             autoQualityFile.setId(0);
             autoQualityFile.setResolution(autoQualityResolution);
         }

--- a/app/src/main/java/net/schueller/peertube/fragment/VideoOptionsFragment.java
+++ b/app/src/main/java/net/schueller/peertube/fragment/VideoOptionsFragment.java
@@ -18,7 +18,9 @@
 package net.schueller.peertube.fragment;
 
 import android.annotation.SuppressLint;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -65,7 +67,7 @@ public class VideoOptionsFragment extends BottomSheetDialogFragment {
         LinearLayout menuRow = (LinearLayout) inflater.inflate(R.layout.row_popup_menu, null);
         TextView iconView = menuRow.findViewById(R.id.video_quality_icon);
         TextView textView = menuRow.findViewById(R.id.video_quality_text);
-        textView.setText(getString(R.string.menu_video_options_playback_speed));
+        textView.setText(String.format(getString(R.string.menu_video_options_playback_speed), videoPlayerService.getPlayBackSpeed()));
         iconView.setText(R.string.video_option_speed_icon);
         new Iconics.IconicsBuilder().ctx(getContext()).on(iconView).build();
         textView.setOnClickListener(view1 -> {
@@ -80,7 +82,7 @@ public class VideoOptionsFragment extends BottomSheetDialogFragment {
         LinearLayout menuRow2 = (LinearLayout) inflater.inflate(R.layout.row_popup_menu, null);
         TextView iconView2 = menuRow2.findViewById(R.id.video_quality_icon);
         TextView textView2 = menuRow2.findViewById(R.id.video_quality_text);
-        textView2.setText(getString(R.string.menu_video_options_quality));
+        textView2.setText(String.format(getString(R.string.menu_video_options_quality), getCurrentVideoQuality(files)));
         iconView2.setText(R.string.video_option_quality_icon);
         new Iconics.IconicsBuilder().ctx(getContext()).on(iconView2).build();
         textView2.setOnClickListener(view1 -> {
@@ -95,4 +97,15 @@ public class VideoOptionsFragment extends BottomSheetDialogFragment {
 
     }
 
+    private String getCurrentVideoQuality(ArrayList<File> files) {
+        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(getContext());
+        Integer videoQuality = sharedPref.getInt("pref_quality", 0);
+
+        for (File file : files) {
+            if (videoQuality.equals(file.getResolution().getId())) {
+                return file.getResolution().getLabel();
+            }
+        }
+        return "Auto";
+    }
 }

--- a/app/src/main/java/net/schueller/peertube/fragment/VideoOptionsFragment.java
+++ b/app/src/main/java/net/schueller/peertube/fragment/VideoOptionsFragment.java
@@ -17,11 +17,9 @@
  */
 package net.schueller.peertube.fragment;
 
-import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/net/schueller/peertube/fragment/VideoOptionsFragment.java
+++ b/app/src/main/java/net/schueller/peertube/fragment/VideoOptionsFragment.java
@@ -37,6 +37,7 @@ import net.schueller.peertube.service.VideoPlayerService;
 import java.util.ArrayList;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 
 public class VideoOptionsFragment extends BottomSheetDialogFragment {
 
@@ -67,7 +68,7 @@ public class VideoOptionsFragment extends BottomSheetDialogFragment {
         LinearLayout menuRow = (LinearLayout) inflater.inflate(R.layout.row_popup_menu, null);
         TextView iconView = menuRow.findViewById(R.id.video_quality_icon);
         TextView textView = menuRow.findViewById(R.id.video_quality_text);
-        textView.setText(String.format(getString(R.string.menu_video_options_playback_speed), videoPlayerService.getPlayBackSpeed()));
+        textView.setText(String.format(getString(R.string.menu_video_options_playback_speed), getCurrentVideoPlaybackSpeedString(videoPlayerService.getPlayBackSpeed())));
         iconView.setText(R.string.video_option_speed_icon);
         new Iconics.IconicsBuilder().ctx(getContext()).on(iconView).build();
         textView.setOnClickListener(view1 -> {
@@ -108,5 +109,15 @@ public class VideoOptionsFragment extends BottomSheetDialogFragment {
         }
         // Returning Automated as a placeholder
         return getString(R.string.menu_video_options_quality_automated);
+    }
+
+    private String getCurrentVideoPlaybackSpeedString(float playbackSpeed) {
+        String speed = String.valueOf(playbackSpeed);
+        // Remove all non-digit characters from the string
+        speed = speed.replaceAll("[^0-9]", "");
+
+        // Dynamically get the localized string corresponding to the speed
+        @StringRes int stringId = getResources().getIdentifier("video_speed_" + speed, "string", videoPlayerService.getPackageName());
+        return getString(stringId);
     }
 }

--- a/app/src/main/java/net/schueller/peertube/fragment/VideoOptionsFragment.java
+++ b/app/src/main/java/net/schueller/peertube/fragment/VideoOptionsFragment.java
@@ -87,7 +87,7 @@ public class VideoOptionsFragment extends BottomSheetDialogFragment {
         new Iconics.IconicsBuilder().ctx(getContext()).on(iconView2).build();
         textView2.setOnClickListener(view1 -> {
             VideoMenuQualityFragment videoMenuQualityFragment =
-                    VideoMenuQualityFragment.newInstance(files);
+                    VideoMenuQualityFragment.newInstance(getContext(), files);
             videoMenuQualityFragment.show(getActivity().getSupportFragmentManager(),
                     videoMenuQualityFragment.TAG);
         });
@@ -106,6 +106,7 @@ public class VideoOptionsFragment extends BottomSheetDialogFragment {
                 return file.getResolution().getLabel();
             }
         }
-        return "Auto";
+        // Returning Automated as a placeholder
+        return getString(R.string.menu_video_options_quality_automated);
     }
 }

--- a/app/src/main/java/net/schueller/peertube/service/VideoPlayerService.java
+++ b/app/src/main/java/net/schueller/peertube/service/VideoPlayerService.java
@@ -178,9 +178,16 @@ public class VideoPlayerService extends Service {
 
     //Playback speed control
     public void setPlayBackSpeed(float speed) {
-
         Log.v(TAG, "setPlayBackSpeed...");
         player.setPlaybackParameters(new PlaybackParameters(speed));
+    }
+
+    /**
+     * Returns the current playback speed of the player.
+     * @return the current playback speed of the player.
+     */
+    public float getPlayBackSpeed() {
+        return player.getPlaybackParameters().speed;
     }
 
     public void playVideo() {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -143,9 +143,9 @@
     <string name="video_meta_button_license">الرخصة</string>
     <string name="video_meta_button_language">اللغة</string>
     <string name="video_meta_button_tags">العلامات</string>
-    <string name="menu_video_options_playback_speed">سرعة التشغيل</string>
-    <string name="menu_video_options_quality">الجودة</string>
-    <string name="account_bottom_menu_videos">الفيديو</string>
+    <string name="menu_video_options_playback_speed" formatted="true">سرعة التشغيل</string>
+    <string name="menu_video_options_quality" formatted="true">(%s) الجودة</string>
+    <string name="account_bottom_menu_videos" formatted="true">الفيديو (s%)</string>
     <string name="account_bottom_menu_channels">القنوات</string>
     <string name="account_bottom_menu_about">حول</string>
     <string name="account_about_account">الحساب:</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -143,9 +143,9 @@
     <string name="video_meta_button_license">الرخصة</string>
     <string name="video_meta_button_language">اللغة</string>
     <string name="video_meta_button_tags">العلامات</string>
-    <string name="menu_video_options_playback_speed" formatted="true">سرعة التشغيل</string>
+    <string name="menu_video_options_playback_speed" formatted="true">سرعة التشغيل (s%)</string>
     <string name="menu_video_options_quality" formatted="true">(%s) الجودة</string>
-    <string name="account_bottom_menu_videos" formatted="true">الفيديو (s%)</string>
+    <string name="account_bottom_menu_videos">الفيديو</string>
     <string name="account_bottom_menu_channels">القنوات</string>
     <string name="account_bottom_menu_about">حول</string>
     <string name="account_about_account">الحساب:</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -285,8 +285,8 @@
     <string name="deeppurple">গাঢ় বেগুনি</string>
     <string name="action_bar_title_account">অ্যাকাউন্ট</string>
     <string name="bottom_nav_title_recent">সাম্প্রতিক</string>
-    <string name="menu_video_options_playback_speed">প্লেব্যাক এর গতি</string>
-    <string name="menu_video_options_quality">কোয়ালিটি</string>
+    <string name="menu_video_options_playback_speed" formatted="true">প্লেব্যাক এর গতি (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">কোয়ালিটি (%s)</string>
     <string name="account_bottom_menu_videos">ভিডিও</string>
     <string name="account_bottom_menu_channels">চ্যানেলগুলি</string>
     <string name="account_bottom_menu_about">সম্পর্কিত</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -276,8 +276,8 @@
     <string name="video_meta_button_license">Lizenz</string>
     <string name="video_meta_button_language">Sprache</string>
     <string name="video_meta_button_tags">Tags</string>
-    <string name="menu_video_options_playback_speed">Wiedergabegeschwindigkeit</string>
-    <string name="menu_video_options_quality">Qualität</string>
+    <string name="menu_video_options_playback_speed" formatted="true">Wiedergabegeschwindigkeit (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">Qualität (%s)</string>
     <string name="account_bottom_menu_videos">Videos</string>
     <string name="account_bottom_menu_channels">Kanäle</string>
     <string name="account_bottom_menu_about">Über</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -96,8 +96,8 @@
     <string name="video_meta_button_license">Licencia</string>
     <string name="video_meta_button_language">Idioma</string>
     <string name="video_meta_button_tags">Etiquetas</string>
-    <string name="menu_video_options_playback_speed">Velocidad de reproducción</string>
-    <string name="menu_video_options_quality">Calidad</string>
+    <string name="menu_video_options_playback_speed" formatted="true">Velocidad de reproducción (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">Calidad (%s)</string>
     <string name="account_bottom_menu_videos">Vídeos</string>
     <string name="account_bottom_menu_channels">Canales</string>
     <string name="account_bottom_menu_about">Acerca de</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -103,7 +103,7 @@
     <string name="mi">maori</string>
     <string name="or">oriya (makrokieli)</string>
     <string name="bi">bislama</string>
-    <string name="menu_video_options_quality">Laatu</string>
+    <string name="menu_video_options_quality" formatted="true">Laatu (%s)</string>
     <string name="api_error">Jotain meni pieleen, yritä myöhemmin!</string>
     <string name="bg">bulgaria</string>
     <string name="uz">uzbekki</string>
@@ -204,7 +204,7 @@
     <string name="nv">navajo</string>
     <string name="kr">kanuri</string>
     <string name="su">sunda</string>
-    <string name="menu_video_options_playback_speed">Toistonopeus</string>
+    <string name="menu_video_options_playback_speed" formatted="true">Toistonopeus (%s)</string>
     <string name="ii">sichuanin-yi</string>
     <string name="red">Punainen</string>
     <string name="video_row_video_thumbnail">Videon esikatselukuva</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -343,4 +343,5 @@
     <string name="title_activity_select_server">Sélectionner un serveur</string>
     <string name="server_book_del_alert_title">Retirer un serveur</string>
     <string name="server_book_del_alert_msg">Voulez-vous vraiment retirer ce serveur de votre carnet d\'adresses ?</string>
+    <string name="menu_video_options_quality_automated">Automatique</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -99,8 +99,8 @@
     <string name="video_meta_button_license">Licence</string>
     <string name="video_meta_button_language">Langue</string>
     <string name="video_meta_button_tags">Étiquettes</string>
-    <string name="menu_video_options_playback_speed">Vitesse de lecture</string>
-    <string name="menu_video_options_quality">Qualité</string>
+    <string name="menu_video_options_playback_speed" formatted="true">Vitesse de lecture (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">Qualité (%s)</string>
     <string name="account_bottom_menu_videos">Vidéos</string>
     <string name="account_bottom_menu_channels">Chaînes</string>
     <string name="account_bottom_menu_about">À propos</string>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -285,8 +285,8 @@
     <string name="video_meta_button_license">Ceadachas</string>
     <string name="video_meta_button_language">Cànan</string>
     <string name="video_meta_button_tags">Tagaichean</string>
-    <string name="menu_video_options_playback_speed">Luaths na cluiche</string>
-    <string name="menu_video_options_quality">Càileachd</string>
+    <string name="menu_video_options_playback_speed" formatted="true">Luaths na cluiche (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">Càileachd (%s)</string>
     <string name="account_bottom_menu_videos">Videothan</string>
     <string name="account_bottom_menu_channels">Seanailean</string>
     <string name="account_bottom_menu_about">Mu dhèidhinn</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -286,8 +286,8 @@
     <string name="video_meta_button_license">Licenza</string>
     <string name="video_meta_button_language">Lingua</string>
     <string name="video_meta_button_tags">Parole chiave</string>
-    <string name="menu_video_options_playback_speed">Velocità di riproduzione</string>
-    <string name="menu_video_options_quality">Qualità</string>
+    <string name="menu_video_options_playback_speed" formatted="true">Velocità di riproduzione (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">Qualità (%s)</string>
     <string name="account_bottom_menu_videos">Video</string>
     <string name="account_bottom_menu_channels">Canali</string>
     <string name="account_bottom_menu_about">A proposito</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -88,8 +88,8 @@
     <string name="video_meta_button_license">ラインセンス</string>
     <string name="video_meta_button_language">言語</string>
     <string name="video_meta_button_tags">タグ</string>
-    <string name="menu_video_options_playback_speed">再生速度</string>
-    <string name="menu_video_options_quality">クオリティ</string>
+    <string name="menu_video_options_playback_speed" formatted="true">再生速度 (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">クオリティ(%s)</string>
     <string name="account_bottom_menu_videos">ビデオ</string>
     <string name="account_bottom_menu_channels">チャンネル</string>
     <string name="account_bottom_menu_about">情報</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -51,8 +51,8 @@
     <string name="video_meta_button_license">Lisens</string>
     <string name="video_meta_button_language">Språk</string>
     <string name="video_meta_button_tags">Etiketter</string>
-    <string name="menu_video_options_playback_speed">Avspillingshastighet</string>
-    <string name="menu_video_options_quality">Kvalitet</string>
+    <string name="menu_video_options_playback_speed" formatted="true">Avspillingshastighet (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">Kvalitet (%s)</string>
     <string name="account_bottom_menu_videos">Videoer</string>
     <string name="account_bottom_menu_channels">Kanaler</string>
     <string name="account_bottom_menu_about">Om</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -275,8 +275,8 @@
     <string name="video_meta_button_license">Licentie</string>
     <string name="video_meta_button_language">Taal</string>
     <string name="video_meta_button_tags">Labels</string>
-    <string name="menu_video_options_playback_speed">Afspeelsnelheid</string>
-    <string name="menu_video_options_quality">Kwaliteit</string>
+    <string name="menu_video_options_playback_speed" formatted="true">Afspeelsnelheid (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">Kwaliteit (%s)</string>
     <string name="account_bottom_menu_videos">Video\'s</string>
     <string name="account_bottom_menu_channels">Kanalen</string>
     <string name="account_bottom_menu_about">Over</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -48,8 +48,8 @@
     <string name="account_about_account">Konto:</string>
     <string name="account_bottom_menu_channels">Kanały</string>
     <string name="account_bottom_menu_videos">Filmy</string>
-    <string name="menu_video_options_quality">Jakość</string>
-    <string name="menu_video_options_playback_speed">Prędkość odtwarzania</string>
+    <string name="menu_video_options_quality" formatted="true">Jakość (%s)</string>
+    <string name="menu_video_options_playback_speed" formatted="true">Prędkość odtwarzania (%s)</string>
     <string name="video_meta_button_tags">Znaczniki</string>
     <string name="video_meta_button_language">Język</string>
     <string name="video_meta_button_license">Licencja</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -277,8 +277,8 @@
     <string name="video_meta_button_license">Лицензия</string>
     <string name="video_meta_button_language">Язык</string>
     <string name="video_meta_button_tags">Теги</string>
-    <string name="menu_video_options_playback_speed">Скорость воспроизведения</string>
-    <string name="menu_video_options_quality">Качество</string>
+    <string name="menu_video_options_playback_speed" formatted="true">Скорость воспроизведения (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">Качество (%s)</string>
     <string name="account_about_description">Описание:</string>
     <string name="api_error">Что-то пошло не так, пожалуйста, попробуйте позже!</string>
     <string name="action_set_url">Выберите сервер</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -272,8 +272,8 @@
     <string name="video_meta_button_license">Licens</string>
     <string name="video_meta_button_language">Språk</string>
     <string name="video_meta_button_tags">Taggar</string>
-    <string name="menu_video_options_playback_speed">Uppspelningshastighet</string>
-    <string name="menu_video_options_quality">Kvalitet</string>
+    <string name="menu_video_options_playback_speed" formatted="true">Uppspelningshastighet (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">Kvalitet (%s)</string>
     <string name="account_bottom_menu_videos">Videor</string>
     <string name="account_bottom_menu_channels">Kanaler</string>
     <string name="account_bottom_menu_about">Om</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -291,8 +291,8 @@
     <string name="video_meta_button_license">Lisans</string>
     <string name="video_meta_button_language">Dil</string>
     <string name="video_meta_button_tags">Etiketler</string>
-    <string name="menu_video_options_playback_speed">Oynatma hızı</string>
-    <string name="menu_video_options_quality">Kalite</string>
+    <string name="menu_video_options_playback_speed" formatted="true">Oynatma hızı (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">Kalite (%s)</string>
     <!-- Constants, Don't translate -->
     <string name="action_bar_title_account">Hesap</string>
     <string name="bottom_nav_title_recent">Yeniler</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -112,8 +112,8 @@
     <string name="video_meta_button_category">类别</string>
     <string name="video_meta_button_license">许可</string>
     <string name="video_meta_button_tags">标签</string>
-    <string name="menu_video_options_playback_speed">播放速度</string>
-    <string name="menu_video_options_quality">画质</string>
+    <string name="menu_video_options_playback_speed" formatted="true">播放速度 (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">画质 (%s)</string>
     <string name="account_bottom_menu_videos">视频</string>
     <string name="account_bottom_menu_channels">频道</string>
     <string name="account_bottom_menu_about">关于</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -279,8 +279,8 @@
     <string name="video_meta_button_license">授權條款</string>
     <string name="video_meta_button_language">語言</string>
     <string name="video_meta_button_tags">標籤</string>
-    <string name="menu_video_options_playback_speed">播放速度</string>
-    <string name="menu_video_options_quality">畫質</string>
+    <string name="menu_video_options_playback_speed" formatted="true">播放速度 (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">畫質 (%s)</string>
     <string name="account_bottom_menu_videos">影片</string>
     <string name="account_bottom_menu_channels">頻道</string>
     <string name="account_bottom_menu_about">關於</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,8 +324,8 @@
     <string name="video_meta_button_license">License</string>
     <string name="video_meta_button_language">Language</string>
     <string name="video_meta_button_tags">Tags</string>
-    <string name="menu_video_options_playback_speed">Playback speed</string>
-    <string name="menu_video_options_quality">Quality</string>
+    <string name="menu_video_options_playback_speed" formatted="true">Playback speed (%s)</string>
+    <string name="menu_video_options_quality" formatted="true">Quality (%s)</string>
     <string name="account_bottom_menu_videos">Videos</string>
     <string name="account_bottom_menu_channels">Channels</string>
     <string name="account_bottom_menu_about">About</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -384,6 +384,7 @@
     <string name="pref_token_type" translatable="false">pref_token_type</string>
     <string name="pref_auth_username" translatable="false">pref_auth_username</string>
     <string name="pref_auth_password" translatable="false">pref_auth_password</string>
+    <string name="menu_video_options_quality_automated">Automated</string>
 
 
 </resources>


### PR DESCRIPTION
This PR introduces a "preview" of the current video playback speed and quality, as follows:
![image](https://user-images.githubusercontent.com/20014332/86520653-4b176000-be47-11ea-854e-445eb70179b0.png)
(the previews are underlined in red)

I'm publishing this PR as a draft, because I need your technical help and opinions about two things:

1. Playback speed is currently displaying the speed float. I am planning to make use of the strings (e.g. `1.25x` instead of `1.25`, `Normal` instead of `1.0`). However, I'm afraid the code will be clumsy. Any tips for this?
2.  See the comments I made down below.