### PR TITLE
New short title

### DIFF
--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Thorium is an unofficial PeerTube Player
+Unofficial PeerTube player

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-Thorium an unofficial PeerTube client
+Thorium


### PR DESCRIPTION
The current title causes an error in translation as there aren't enough available chars.
The shorter alternative title (The Thorium PeerTube Client) Is 27, of a limit of 30 chars 123456789012345678901234567890 so it will also fail in some languages

I don't really know how the searching works on the Play store. Is there a penalty for being over in English?
Does Thorium show up when searching for "PeerTube"?