### PR TITLE
Fix incomplete description in video view

### DIFF
--- a/app/src/main/java/net/schueller/peertube/network/GetVideoDataService.java
+++ b/app/src/main/java/net/schueller/peertube/network/GetVideoDataService.java
@@ -48,6 +48,11 @@ public interface GetVideoDataService {
             @Path(value = "id", encoded = true) String id
     );
 
+    @GET("videos/{id}/description")
+    Call<Object> getVideoFullDescription(
+            @Path(value = "id", encoded = true) String id
+    );
+
     @GET("search/videos/")
     Call<VideoList> searchVideosData(
             @Query("start") int start,

--- a/app/src/main/res/layout/activity_video_play.xml
+++ b/app/src/main/res/layout/activity_video_play.xml
@@ -28,8 +28,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
-                <fragment android:name="net.schueller.peertube.fragment.VideoMetaDataFragment"
+                <fragment
                     android:id="@+id/video_meta_data_fragment"
+                    android:name="net.schueller.peertube.fragment.VideoMetaDataFragment"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content" />
 


### PR DESCRIPTION
This adds an API call to get the complete video description.

There's still room for improvement in this PR : my code's messy as hell, and I'd especially like to get your feedback on how to handle the two requests that are now necessary to start playing the video (get video data and get complete video description).

