### PR TITLE
fix: set required (im)mutable flag when creating pending intent

### DIFF
--- a/app/src/main/java/net/schueller/peertube/activity/VideoPlayActivity.kt
+++ b/app/src/main/java/net/schueller/peertube/activity/VideoPlayActivity.kt
@@ -54,9 +54,10 @@ class VideoPlayActivity : CommonActivity() {
         val videoPlayerFragment =
             fragmentManager.findFragmentById(R.id.video_player_fragment) as VideoPlayerFragment?
         val actions = ArrayList<RemoteAction>()
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
         var actionIntent = Intent(getString(R.string.app_background_audio))
         var pendingIntent =
-            PendingIntent.getBroadcast(applicationContext, REQUEST_CODE, actionIntent, 0)
+            PendingIntent.getBroadcast(applicationContext, REQUEST_CODE, actionIntent, flags)
         @SuppressLint("NewApi", "LocalSuppress") var icon = Icon.createWithResource(
             applicationContext, android.R.drawable.stat_sys_speakerphone
         )
@@ -65,7 +66,7 @@ class VideoPlayActivity : CommonActivity() {
         actions.add(remoteAction)
         actionIntent = Intent(PlayerNotificationManager.ACTION_STOP)
         pendingIntent =
-            PendingIntent.getBroadcast(applicationContext, REQUEST_CODE, actionIntent, 0)
+            PendingIntent.getBroadcast(applicationContext, REQUEST_CODE, actionIntent, flags)
         icon = Icon.createWithResource(
             applicationContext,
             com.google.android.exoplayer2.ui.R.drawable.exo_notification_stop
@@ -77,7 +78,7 @@ class VideoPlayActivity : CommonActivity() {
             Log.e(TAG, "setting actions with play button")
             actionIntent = Intent(PlayerNotificationManager.ACTION_PLAY)
             pendingIntent =
-                PendingIntent.getBroadcast(applicationContext, REQUEST_CODE, actionIntent, 0)
+                PendingIntent.getBroadcast(applicationContext, REQUEST_CODE, actionIntent, flags)
             icon = Icon.createWithResource(
                 applicationContext,
                 com.google.android.exoplayer2.ui.R.drawable.exo_notification_play
@@ -87,7 +88,7 @@ class VideoPlayActivity : CommonActivity() {
             Log.e(TAG, "setting actions with pause button")
             actionIntent = Intent(PlayerNotificationManager.ACTION_PAUSE)
             pendingIntent =
-                PendingIntent.getBroadcast(applicationContext, REQUEST_CODE, actionIntent, 0)
+                PendingIntent.getBroadcast(applicationContext, REQUEST_CODE, actionIntent, flags)
             icon = Icon.createWithResource(
                 applicationContext,
                 com.google.android.exoplayer2.ui.R.drawable.exo_notification_pause

--- a/app/src/main/java/net/schueller/peertube/service/VideoPlayerService.kt
+++ b/app/src/main/java/net/schueller/peertube/service/VideoPlayerService.kt
@@ -16,6 +16,7 @@
  */
 package net.schueller.peertube.service
 
+import android.annotation.SuppressLint
 import android.app.Notification
 import net.schueller.peertube.helper.MetaDataHelper.getMetaString
 import net.schueller.peertube.model.Video.Companion.getMediaDescription
@@ -46,6 +47,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.net.Uri
 import android.os.Binder
+import android.os.Build
 import android.util.Log
 import android.webkit.URLUtil
 import androidx.core.app.NotificationCompat
@@ -217,11 +219,15 @@ class VideoPlayerService : Service() {
                         return currentVideo!!.name
                     }
 
+                    @SuppressLint("UnspecifiedImmutableFlag")
                     override fun createCurrentContentIntent(player: Player): PendingIntent? {
                         val intent = Intent(context, VideoPlayActivity::class.java)
                         intent.putExtra(VideoListActivity.EXTRA_VIDEOID, currentVideo!!.uuid)
-                        return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
 
+                        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+                            PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+                        else
+                            PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
                     }
 
                     override fun getCurrentContentText(player: Player): CharSequence {


### PR DESCRIPTION
When targeting SDK S+ (version 31 and above) a (im)mutable flag is required when creating a PendingIntent.

As the current minSdkVersion is 21 a SDK version check is included to ensure the device is at least SDK M (version 23) which is when the flags were added.

https://developer.android.com/reference/android/app/PendingIntent#FLAG_IMMUTABLE

Exception trace from a android 12 device:
```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: net.schueller.peertube, PID: 25925
    java.lang.IllegalArgumentException: net.schueller.peertube: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
        at android.app.PendingIntent.checkFlags(PendingIntent.java:375)
        at android.app.PendingIntent.getActivityAsUser(PendingIntent.java:458)
        at android.app.PendingIntent.getActivity(PendingIntent.java:444)
        at android.app.PendingIntent.getActivity(PendingIntent.java:408)
        at net.schueller.peertube.service.VideoPlayerService$playVideo$1.createCurrentContentIntent(VideoPlayerService.kt:223)
        at com.google.android.exoplayer2.ui.PlayerNotificationManager.createNotification(PlayerNotificationManager.java:1276)
        at com.google.android.exoplayer2.ui.PlayerNotificationManager.startOrUpdateNotification(PlayerNotificationManager.java:1151)
        at com.google.android.exoplayer2.ui.PlayerNotificationManager.handleMessage(PlayerNotificationManager.java:1409)
        at com.google.android.exoplayer2.ui.PlayerNotificationManager.$r8$lambda$hDN6RMWHvTCSAt_reWH1_HHmp5E(Unknown Source:0)
        at com.google.android.exoplayer2.ui.PlayerNotificationManager$$ExternalSyntheticLambda0.handleMessage(Unknown Source:2)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7842)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```